### PR TITLE
update link to the 2018 CfS

### DIFF
--- a/2014/2014-06-12_how-to-write-a-great-talk-proposal-for-a-tech/2014-06-12_how-to-write-a-great-talk-proposal-for-a-tech.md
+++ b/2014/2014-06-12_how-to-write-a-great-talk-proposal-for-a-tech/2014-06-12_how-to-write-a-great-talk-proposal-for-a-tech.md
@@ -13,9 +13,9 @@ You’ve watched countless talks online. You’ve written a blog post, or ten. Y
 
 Well, we think so, too! It’s time to get your talk proposals ready for the upcoming conference season, and we have some tips and insights on how to write a compelling talk proposal that will help you conquer the big conference stages.
 
-🔔 CfS open now: The 2017 CSSconf EU Call for Speakers is open for submissions until January 10 2017. As always, we are super excited to receive yours!
+🔔 CfS open now: The 2018 CSSconf EU Call for Speakers is open for submissions until January 1 2018. As always, we are super excited to receive yours!
 
-<a href="http://2017.cssconf.eu/call-for-speakers" class="btn--special">
+<a href="http://2018.cssconf.eu/call-for-speakers" class="btn--special">
   <span class="btn__span" data-hover="Submit a Talk Proposal">Submit a Talk Proposal</span>
 </a>
 
@@ -127,8 +127,8 @@ Many others have shared their insights on how to write successful talk proposals
 
 * * *
 
-🔔 CfS open now: The 2017 CSSconf EU Call for Speakers is open for submissions until January 10 2017. As always, we are super excited to receive yours!
+🔔 CfS open now: The 2018 CSSconf EU Call for Speakers is open for submissions until January 1 2018. As always, we are super excited to receive yours!
 
-<a href="http://2017.cssconf.eu/call-for-speakers" class="btn--special">
+<a href="http://2018.cssconf.eu/call-for-speakers" class="btn--special">
   <span class="btn__span" data-hover="Submit a Talk Proposal">Submit a Talk Proposal</span>
 </a>


### PR DESCRIPTION
This blogpost now links to the current CfS:
http://blog.cssconf.eu/2014/06/12/how-to-write-a-great-talk-proposal-for-a-tech/